### PR TITLE
Maintenance also inside docker container

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -55,8 +55,12 @@ data retention policies according to the configured policy.
 
 **Example:**
 
-```postgresql
-CALL execute_maintenance();
+```bash
+docker exec \
+   --user postgres \
+   timescaledb \
+      psql \
+        -c "CALL execute_maintenance();"
 ```
 
 ## 🔥 Configuring Prometheus to use this remote storage connector


### PR DESCRIPTION
Wrapped the maintenance example in `docker exec`.
Provides the information I did mis:
* How? (`docker exec`)
* Which container? (`timescaledb`)
* Which user inside the container? (`postgres`)
* Which program in the container? (`psql`)